### PR TITLE
chore(commitlint): remove custom body length rule

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,9 +1,0 @@
-export default {
-  extends: ['@commitlint/config-conventional'],
-  /*
-   * Any rules defined here will override rules from @commitlint/config-conventional
-   */
-  rules: {
-    'body-max-line-length': [2, 'always', 200],
-  },
-};


### PR DESCRIPTION
Removes the custom body-max-line-length rule from the 
commitlint configuration. This simplifies the config 
and uses the default line length provided by the 
@commitlint/config-conventional package.